### PR TITLE
DO-2 - add ecs task execution role & ecr repository

### DIFF
--- a/AutoDocs-ecs/main.tf
+++ b/AutoDocs-ecs/main.tf
@@ -21,3 +21,8 @@ module "nat_gateway" {
     internet_gateway              = module.vpc.internet_gateway
     vpc_id                        = module.vpc.vpc_id
 }
+
+module "ecs-task-execution-role" {
+    source                        = "../modules/ecs-task-execution-role"
+    project_name                  = module.vpc.project_name
+}

--- a/AutoDocs-ecs/main.tf
+++ b/AutoDocs-ecs/main.tf
@@ -22,7 +22,13 @@ module "nat_gateway" {
     vpc_id                        = module.vpc.vpc_id
 }
 
+# Create ECS task execution role
 module "ecs-task-execution-role" {
     source                        = "../modules/ecs-task-execution-role"
+    project_name                  = module.vpc.project_name
+}
+
+module "ecr" {
+    source                        = "../modules/ecr"
     project_name                  = module.vpc.project_name
 }

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,16 @@
+resource "aws_ecr_repository" "backend_repo" {
+  name                 = "${var.project_name}-backend-repo"
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "${var.project_name}-backend-repo"
+  }
+}

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "ecr_repository_url" {
+  description = "The URL of the ECR repository"
+  value       = aws_ecr_repository.backend_repo.repository_url
+}
+
+output "ecr_repository_arn" {
+  description = "The ARN of the ECR repository"
+  value       = aws_ecr_repository.backend_repo.arn
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,1 @@
+variable "project_name" {}

--- a/modules/ecs-task-execution-role/main.tf
+++ b/modules/ecs-task-execution-role/main.tf
@@ -1,4 +1,4 @@
-# generates an iam policy document in json format for the ecs task execution role
+# Generates an IAM policy document in JSON format for the ECS task execution role
 data "aws_iam_policy_document" "ecs_tasks_execution_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -10,14 +10,48 @@ data "aws_iam_policy_document" "ecs_tasks_execution_role_policy" {
   }
 }
 
-# create an iam role
+# Create an IAM role for ECS Task Execution
 resource "aws_iam_role" "ecs_tasks_execution_role" {
   name                = "${var.project_name}-ecs-task-execution-role"
   assume_role_policy  = data.aws_iam_policy_document.ecs_tasks_execution_role_policy.json
 }
 
-# attach ecs task execution policy to the iam role
+# Attach the ECS Task Execution Policy
 resource "aws_iam_role_policy_attachment" "ecs_tasks_execution_role" {
   role       = aws_iam_role.ecs_tasks_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Create an additional policy for ECR access
+resource "aws_iam_policy" "ecr_access_policy" {
+  name        = "${var.project_name}-ecr-access-policy"
+  description = "Allows ECS tasks to pull images from ECR"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Attach the ECR access policy to the ECS task execution role
+resource "aws_iam_role_policy_attachment" "ecs_ecr_access" {
+  role       = aws_iam_role.ecs_tasks_execution_role.name
+  policy_arn = aws_iam_policy.ecr_access_policy.arn
 }

--- a/modules/ecs-task-execution-role/main.tf
+++ b/modules/ecs-task-execution-role/main.tf
@@ -1,0 +1,23 @@
+# generates an iam policy document in json format for the ecs task execution role
+data "aws_iam_policy_document" "ecs_tasks_execution_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# create an iam role
+resource "aws_iam_role" "ecs_tasks_execution_role" {
+  name                = "${var.project_name}-ecs-task-execution-role"
+  assume_role_policy  = data.aws_iam_policy_document.ecs_tasks_execution_role_policy.json
+}
+
+# attach ecs task execution policy to the iam role
+resource "aws_iam_role_policy_attachment" "ecs_tasks_execution_role" {
+  role       = aws_iam_role.ecs_tasks_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/modules/ecs-task-execution-role/outputs.tf
+++ b/modules/ecs-task-execution-role/outputs.tf
@@ -1,0 +1,3 @@
+output "ecs_task_execution_role_arn" {
+  value = aws_iam_role.ecs_tasks_execution_role.arn
+}

--- a/modules/ecs-task-execution-role/outputs.tf
+++ b/modules/ecs-task-execution-role/outputs.tf
@@ -1,3 +1,7 @@
 output "ecs_task_execution_role_arn" {
   value = aws_iam_role.ecs_tasks_execution_role.arn
 }
+
+output "ecr_access_policy_arn" {
+  value = aws_iam_policy.ecr_access_policy.arn
+}

--- a/modules/ecs-task-execution-role/variables.tf
+++ b/modules/ecs-task-execution-role/variables.tf
@@ -1,0 +1,1 @@
+variable "project_name" {}


### PR DESCRIPTION
#### **Changes Implemented**  
- **Created ECS Task Execution Role** (`ecs_tasks_execution_role`)  
  - Allows ECS tasks to assume the required IAM role.  
  - Grants permissions for pulling images from ECR.  
  - Attached `AmazonECSTaskExecutionRolePolicy` for essential ECS execution permissions.  
  - Added a custom policy for ECR access (`ecr:GetDownloadUrlForLayer`, `ecr:BatchGetImage`, etc.).  

- **Created ECR Repository** (`backend_repo`)  
  - Enables storing and managing Docker images for backend services.  
  - Configured image scanning on push.  
  - Enabled AES256 encryption for security.  

- **Added Terraform Outputs for Better Accessibility**  
  - `ecr_repository_url`: Provides the ECR repository URL for pushing images.  
  - `ecr_repository_arn`: ARN reference for IAM policies.  